### PR TITLE
Refactor/robust csv reader

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/dal/CsvStockReader.java
+++ b/src/main/java/edu/ntnu/idi/idatt/dal/CsvStockReader.java
@@ -4,26 +4,37 @@ import edu.ntnu.idi.idatt.dal.exception.StockParsingException;
 import edu.ntnu.idi.idatt.model.Stock;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 public class CsvStockReader implements DataReader<List<Stock>> {
 
   private static final Logger LOGGER = Logger.getLogger(CsvStockReader.class.getName());
+  private static final int EXPECTED_COLUMN_COUNT = 3;
 
   public CsvStockReader() {
   }
 
   @Override
   public List<Stock> read(String source) throws IOException, StockParsingException {
+    Path path = Path.of(source);
+
+    if (!Files.exists(path)) {
+      throw new IOException("File not found: " + source);
+    }
+    if (!Files.isReadable(path)) {
+      throw new IOException("File is not readable: " + source);
+    }
+
     List<Stock> stocks = new ArrayList<>();
 
-    try (BufferedReader br = new BufferedReader(new FileReader(source))) {
+    try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
       String line;
       int lineNumber = 0;
       while ((line = br.readLine()) != null) {
@@ -32,16 +43,17 @@ public class CsvStockReader implements DataReader<List<Stock>> {
           continue;
         }
         try {
-          parseLineToStock(line).ifPresent(stocks::add);
+          stocks.add(parseLineToStock(line));
         } catch (StockParsingException e) {
-          LOGGER.warning("Line " + lineNumber + ": " + e.getMessage());
+          LOGGER.warning("Skipping line " + lineNumber + ": " + e.getMessage());
         }
-
-      }
-      if (stocks.isEmpty()) {
-        throw new StockParsingException("Source file was empty or contained no valid stocks.");
       }
     }
+
+    if (stocks.isEmpty()) {
+      throw new StockParsingException("File contained no valid stocks: " + source);
+    }
+
     return stocks;
   }
 
@@ -49,22 +61,37 @@ public class CsvStockReader implements DataReader<List<Stock>> {
     return line.startsWith("#") || line.trim().isBlank();
   }
 
-  private static Optional<Stock> parseLineToStock(String line) throws StockParsingException {
+  private static Stock parseLineToStock(String line) throws StockParsingException {
     String[] data = line.split(",");
 
-    if (data.length != 3) {
-      throw new StockParsingException("Malformed stock row (expected 3 columns): " + line);
+    if (data.length != EXPECTED_COLUMN_COUNT) {
+      throw new StockParsingException(
+          "Expected " + EXPECTED_COLUMN_COUNT + " columns but got " + data.length + ": " + line);
     }
 
+    String symbol = data[0].trim();
+    String company = data[1].trim();
+    String priceRaw = data[2].trim();
+
+    if (symbol.isBlank()) {
+      throw new StockParsingException("Symbol is blank in line: " + line);
+    }
+    if (company.isBlank()) {
+      throw new StockParsingException("Company name is blank in line: " + line);
+    }
+
+    BigDecimal price;
     try {
-      String symbol = data[0].trim();
-      String company = data[1].trim();
-      BigDecimal price = new BigDecimal(data[2].trim());
-
-      return Optional.of(new Stock(symbol, company, new ArrayList<>(List.of(price))));
-    } catch (Exception e) {
-      throw new StockParsingException("Error parsing stock values in line: " + line, e);
+      price = new BigDecimal(priceRaw);
+    } catch (NumberFormatException e) {
+      throw new StockParsingException("Invalid price value '" + priceRaw + "' in line: " + line, e);
     }
+
+    if (price.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new StockParsingException("Price must be positive, got '" + price + "' in line: " + line);
+    }
+
+    return new Stock(symbol, company, new ArrayList<>(List.of(price)));
   }
 
 }

--- a/src/test/java/edu/ntnu/idi/idatt/dal/CsvStockReaderTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/dal/CsvStockReaderTest.java
@@ -64,8 +64,107 @@ class CsvStockReaderTest {
   void testParseNonExistentFileThrowsIOException() {
     Path filePath = tempDir.resolve("test_stocks.csv");
     assertThrows(IOException.class, () -> stockReader.read(filePath.toString()));
-
   }
 
+  @Test
+  void testReadEmptyFileThrowsDataAccessException() throws IOException {
+    Path filePath = tempDir.resolve("empty.csv");
+    Files.writeString(filePath, "");
+
+    assertThrows(DataAccessException.class, () -> stockReader.read(filePath.toString()),
+        "Empty file should throw DataAccessException");
+  }
+
+  @Test
+  void testReadOnlyCommentsAndBlankLinesThrowsDataAccessException() throws IOException {
+    Path filePath = tempDir.resolve("comments_only.csv");
+    String content = """
+        # Ticker,Name,Price
+
+        # Another comment
+        """;
+    Files.writeString(filePath, content);
+
+    assertThrows(DataAccessException.class, () -> stockReader.read(filePath.toString()),
+        "File with only comments and blank lines should throw DataAccessException");
+  }
+
+  @Test
+  void testReadBlankSymbolSkipsLine() throws IOException, DataAccessException {
+    Path filePath = tempDir.resolve("blank_symbol.csv");
+    String content = """
+        , Apple Inc., 276.43
+        NVDA, Nvidia, 191.27
+        """;
+    Files.writeString(filePath, content);
+
+    List<Stock> stocks = stockReader.read(filePath.toString());
+
+    assertEquals(1, stocks.size(), "Line with blank symbol should be skipped");
+    assertEquals("NVDA", stocks.getFirst().getSymbol());
+  }
+
+  @Test
+  void testReadBlankCompanySkipsLine() throws IOException, DataAccessException {
+    Path filePath = tempDir.resolve("blank_company.csv");
+    String content = """
+        AAPL, , 276.43
+        NVDA, Nvidia, 191.27
+        """;
+    Files.writeString(filePath, content);
+
+    List<Stock> stocks = stockReader.read(filePath.toString());
+
+    assertEquals(1, stocks.size(), "Line with blank company should be skipped");
+    assertEquals("NVDA", stocks.getFirst().getSymbol());
+  }
+
+  @Test
+  void testReadZeroPriceSkipsLine() throws IOException, DataAccessException {
+    Path filePath = tempDir.resolve("zero_price.csv");
+    String content = """
+        AAPL, Apple Inc., 0
+        NVDA, Nvidia, 191.27
+        """;
+    Files.writeString(filePath, content);
+
+    List<Stock> stocks = stockReader.read(filePath.toString());
+
+    assertEquals(1, stocks.size(), "Line with zero price should be skipped");
+    assertEquals("NVDA", stocks.getFirst().getSymbol());
+  }
+
+  @Test
+  void testReadNegativePriceSkipsLine() throws IOException, DataAccessException {
+    Path filePath = tempDir.resolve("negative_price.csv");
+    String content = """
+        AAPL, Apple Inc., -50.00
+        NVDA, Nvidia, 191.27
+        """;
+    Files.writeString(filePath, content);
+
+    List<Stock> stocks = stockReader.read(filePath.toString());
+
+    assertEquals(1, stocks.size(), "Line with negative price should be skipped");
+    assertEquals("NVDA", stocks.getFirst().getSymbol());
+  }
+
+  @Test
+  void testReadInvalidLinesAreSkippedAndValidOnesReturned() throws IOException, DataAccessException {
+    Path filePath = tempDir.resolve("mixed.csv");
+    String content = """
+        AAPL, Apple Inc., 276.43
+        BAD_ROW_TOO_MANY, Extra, Columns, Here
+        NVDA, Nvidia, not_a_number
+        GOOG, Alphabet, 185.50
+        """;
+    Files.writeString(filePath, content);
+
+    List<Stock> stocks = stockReader.read(filePath.toString());
+
+    assertEquals(2, stocks.size(), "Only valid lines should be returned");
+    assertEquals("AAPL", stocks.get(0).getSymbol());
+    assertEquals("GOOG", stocks.get(1).getSymbol());
+  }
 
 }


### PR DESCRIPTION
Refactor CSV stock reader to make it more robust against wrong values

Throws more describing exceptions

Uses now ``` Files.newBufferedReader(path, StandardCharsets.UTF_8) ``` to enure compatability with all platforms